### PR TITLE
Cleaning up light limits

### DIFF
--- a/Assets/Prefabs/Frog.prefab
+++ b/Assets/Prefabs/Frog.prefab
@@ -156,7 +156,7 @@ LineRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10301, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 77c02caab4a876bd4aac7f7d5f1e06ee, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefabs/Lights/Point Lamp.prefab
+++ b/Assets/Prefabs/Lights/Point Lamp.prefab
@@ -101,6 +101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sparks: {fileID: 634278166950957639}
+  light: {fileID: 5490333106156900489}
 --- !u!70 &9137194527988666746
 CapsuleCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Lights/IntensityRange.cs
+++ b/Assets/Scripts/Lights/IntensityRange.cs
@@ -12,6 +12,13 @@ public class IntensityRange : MonoBehaviour
     }
     void Update()
     {
-        controlledLight.pointLightOuterRadius = controlledLight.intensity * rangeMultiplier;
+        if (LightLimit.IsOverVoltage)
+        {
+            controlledLight.pointLightOuterRadius = 0;
+        }
+        else
+        {
+            controlledLight.pointLightOuterRadius = controlledLight.intensity * rangeMultiplier;
+        }
     }
 }

--- a/Assets/Scripts/Lights/SparkController.cs
+++ b/Assets/Scripts/Lights/SparkController.cs
@@ -5,10 +5,12 @@ using UnityEngine;
 public class SparkController : MonoBehaviour
 {
     public ParticleSystem sparks;
+    public UnityEngine.Rendering.Universal.Light2D light;
 
     // Update is called once per frame
     void Update()
     {
-        sparks.gameObject.SetActive(LightLimit.IsOverVoltage);
+        bool shouldSpark = LightLimit.IsOverVoltage && light.enabled;
+        sparks.gameObject.SetActive(shouldSpark);
     }
 }


### PR DESCRIPTION
Improving visual clarity of light limits.
- Only lights that are enabled create sparks so it's obvious which lights are contributing to the light consumption.
- When the light usage limit is reached all lights stop producing light and spark instead.
Resolves #41 