### PR TITLE
Adding animation curve to frog tongue

### DIFF
--- a/Assets/Prefabs/Frog.prefab
+++ b/Assets/Prefabs/Frog.prefab
@@ -133,6 +133,57 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   lineRenderer: {fileID: 3200697175394705766}
   edgeCollider: {fileID: 7521166667555434458}
+  accelerationCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 2
+      outSlope: 2
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    - serializedVersion: 3
+      time: 0.09659425
+      value: 3.9736462
+      inSlope: 6.0196137
+      outSlope: 6.0196137
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.5546821
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.307434
+      value: 1.8917897
+      inSlope: -8.601762
+      outSlope: -8.601762
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.07302646
+      outWeight: 0.122710116
+    - serializedVersion: 3
+      time: 0.5998253
+      value: 1.2845268
+      inSlope: -0.029314
+      outSlope: -0.029314
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.17010617
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 1.2036743
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0
+      outWeight: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
   eatingPeriod: 1
   speed: 3
   fieldOfView: 30

--- a/Assets/Scenes/Level1.unity
+++ b/Assets/Scenes/Level1.unity
@@ -1179,7 +1179,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6577258862630230776, guid: caba3be02061447f3b4db9b1b23f08b1, type: 3}
       propertyPath: orthographic size
-      value: 7.541582
+      value: 6.253995
       objectReference: {fileID: 0}
     - target: {fileID: 6577258862630230779, guid: caba3be02061447f3b4db9b1b23f08b1, type: 3}
       propertyPath: m_Name

--- a/Assets/Scripts/FrogTongue.cs
+++ b/Assets/Scripts/FrogTongue.cs
@@ -7,6 +7,7 @@ public class FrogTongue : MonoBehaviour
     public LineRenderer lineRenderer;
 
     public EdgeCollider2D edgeCollider;
+    public AnimationCurve accelerationCurve;
 
     public int eatingPeriod = 1;
 
@@ -29,6 +30,7 @@ public class FrogTongue : MonoBehaviour
         mothBuffer = new ParticleSystem.Particle[100];
 
     private float hunger = 0;
+    private float timeElapsed = 0;
 
     // Start is called before the first frame update
     void Start()
@@ -48,6 +50,7 @@ public class FrogTongue : MonoBehaviour
     void Update()
     {
         hunger += Time.deltaTime;
+        timeElapsed += Time.deltaTime;
         if (target.HasValue && !ObjectInRange(target.Value))
         {
             targetSelf = true;
@@ -75,6 +78,7 @@ public class FrogTongue : MonoBehaviour
 
     void FindNewTarget()
     {
+        timeElapsed = 0;
         if (targetSelf)
         {
             target = tongue.transform.position;
@@ -123,7 +127,7 @@ public class FrogTongue : MonoBehaviour
         Vector3 oldPosition = lineRenderer.GetPosition(1);
         Vector3 vecToTarget = target - oldPosition;
         Vector3 dirToTarget = vecToTarget.normalized;
-        float distanceToMove = speed * Time.deltaTime;
+        float distanceToMove = speed * Time.deltaTime * accelerationCurve.Evaluate(timeElapsed);
 
         // Update tongue end position
         Vector3 newPosition = oldPosition + dirToTarget * distanceToMove;
@@ -143,6 +147,6 @@ public class FrogTongue : MonoBehaviour
             edges.Add(new Vector2(linePoint.x, linePoint.y));
         }
 
-        edgeCollider.SetPoints (edges);
+        edgeCollider.SetPoints(edges);
     }
 }


### PR DESCRIPTION
The animation curve is sampled over the eating animation to create a non-linear acceleration curve. This makes the tongue animation look more realistic.
Resolves #51 