### PR TITLE
Fixing build errors 

### DIFF
--- a/Assets/Scripts/Lights/LightBuilder.cs
+++ b/Assets/Scripts/Lights/LightBuilder.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.Rendering.Universal;
+using UnityEditor;
 
 public class LightBuilder : MonoBehaviour
 {
@@ -9,16 +10,19 @@ public class LightBuilder : MonoBehaviour
     [HideInInspector]
     public Light2D light2D;
 
-    private void OnValidate() => UnityEditor.EditorApplication.delayCall += _OnValidate;
+#if UNITY_EDITOR
+    private void OnValidate() => EditorApplication.delayCall += _OnValidate;
 
     void _OnValidate()
     {
-        UnityEditor.EditorApplication.delayCall -= _OnValidate;
+        EditorApplication.delayCall -= _OnValidate;
         if (this == null) return;
         CheckActivationType();
         CheckAreaOfEffect();
         CheckStartOn();
     }
+
+#endif
 
     void CheckActivationType()
     {


### PR DESCRIPTION
The build errors were caused by some code in the light builder script that should only run while in editor mode. I added a `#if UNITY_EDITOR` statement to prevent the code from running in the production build.

![image](https://user-images.githubusercontent.com/32989729/201996298-0b43e898-07d0-44c4-9f09-429d82d639c4.png)\
Resolves #247 
