### PR TITLE
Fixing autoplay lights

### DIFF
--- a/Assets/Scripts/Lights/AutoPlayLevel.cs
+++ b/Assets/Scripts/Lights/AutoPlayLevel.cs
@@ -5,6 +5,8 @@ using System.Collections;
 public class AutoPlayLevel : MonoBehaviour
 {
     public Light2D[] lights;
+    [SerializeField]
+    private IntEventChannelSO lightChannel;
 
     void Start()
     {
@@ -25,16 +27,9 @@ public class AutoPlayLevel : MonoBehaviour
         while (lightIndex < lights.Length)
         {
             yield return new WaitForSeconds(5);
-            ToggleLight(lightIndex - 1);
-            ToggleLight(lightIndex);
+            lightChannel.RaiseEvent(lightIndex - 1);
+            lightChannel.RaiseEvent(lightIndex);
             lightIndex++;
         }
     }
-
-    void ToggleLight(int index)
-    {
-        if (index >= lights.Length || index < 0) return;
-        lights[index].enabled = !lights[index].enabled;
-    }
-
 }

--- a/Assets/Scripts/Lights/LightController.cs
+++ b/Assets/Scripts/Lights/LightController.cs
@@ -30,7 +30,9 @@ public class LightController : MonoBehaviour
             GameObject
                 .FindGameObjectWithTag("AudioManager")
                 .GetComponent<AudioManager>();
-        lightLimit = GameObject.Find("RadialLightLimit").GetComponent<RadialLightLimit>();
+        GameObject lightLimitObj = GameObject.Find("RadialLightLimit");
+        if (lightLimitObj != null)
+            lightLimit = lightLimitObj.GetComponent<RadialLightLimit>();
         mainCam = Camera.main;
         UICamera = GameObject.Find("UICamera").GetComponent<Camera>();
         _ringController = luxRings.GetComponent<LuxRings>();
@@ -108,6 +110,14 @@ public class LightController : MonoBehaviour
 
     public IEnumerator BrightenLight()
     {
+        if (lightLimit == null)
+        {
+            myLight.intensity += 1;
+            _requestedIntensity += 1;
+            SwitchLightState();
+            _processing = false;
+            yield break;
+        }
         if (!lightLimit.LuxAvailable(1))
         {
             // If there isn't enough lux, the light cannot increase in brightness.
@@ -128,12 +138,18 @@ public class LightController : MonoBehaviour
         _processing = false;
     }
 
-    IEnumerator DimLight()
+    public IEnumerator DimLight()
     {
         myLight.intensity -= 1;
         if (myLight.intensity == 0)
         {
             SwitchLightState();
+        }
+        if (lightLimit == null)
+        {
+            _processing = false;
+            _requestedIntensity -= 1;
+            yield break;
         }
         if (lightData.returnsLux)
         {

--- a/Assets/Scripts/Lights/ZoneToggleLight.cs
+++ b/Assets/Scripts/Lights/ZoneToggleLight.cs
@@ -23,7 +23,14 @@ public class ZoneToggleLight : MonoBehaviour
     {
         if (subscribedZones.Contains(zoneId))
         {
-            StartCoroutine(lightController.BrightenLight());
+            if (lightController.myLight.intensity <= 0)
+            {
+                StartCoroutine(lightController.BrightenLight());
+            }
+            else
+            {
+                StartCoroutine(lightController.DimLight());
+            }
         }
     }
 }


### PR DESCRIPTION
The autoplay sequence keeps breaking because it uses a proprietary way of turning on/off the lights instead of using the standard way. I completely overhauled how to autoplay sequence works so that it uses standard mechanisms. It now sends sends a sequence of toggle lights events on the ToggleLightEventSO channel to turn the lights on and off.

Resolves #248 