### PR TITLE
Improving Level Select Load

### DIFF
--- a/Assets/Audio/Frog.mp3.meta
+++ b/Assets/Audio/Frog.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 1
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/DEAD SOLDIERS THEME.mp3.meta
+++ b/Assets/Audio/Music/DEAD SOLDIERS THEME.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Delusion.mp3.meta
+++ b/Assets/Audio/Music/Delusion.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Full of memories.ogg.meta
+++ b/Assets/Audio/Music/Full of memories.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Journey to the East Rocks.ogg.meta
+++ b/Assets/Audio/Music/Journey to the East Rocks.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Mystery Forest.mp3.meta
+++ b/Assets/Audio/Music/Mystery Forest.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Path to Lake Land.ogg.meta
+++ b/Assets/Audio/Music/Path to Lake Land.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Please, answer me my friend.mp3.meta
+++ b/Assets/Audio/Music/Please, answer me my friend.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Time to buy a new sword.mp3.meta
+++ b/Assets/Audio/Music/Time to buy a new sword.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/Wind and tree.mp3.meta
+++ b/Assets/Audio/Music/Wind and tree.mp3.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Music/destiny.wav.meta
+++ b/Assets/Audio/Music/destiny.wav.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 2
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/Sound Effects/complete.ogg.meta
+++ b/Assets/Audio/Sound Effects/complete.ogg.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 1
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1

--- a/Assets/Audio/switch10.wav.meta
+++ b/Assets/Audio/switch10.wav.meta
@@ -4,7 +4,7 @@ AudioImporter:
   externalObjects: {}
   serializedVersion: 6
   defaultSettings:
-    loadType: 0
+    loadType: 1
     sampleRateSetting: 0
     sampleRateOverride: 44100
     compressionFormat: 1


### PR DESCRIPTION
Decreasing the load time for the level selection page by changing the compression formats for game sound. Music files are no longer loaded into memory preemptively and are instead streamed from disk when they are needed. Other sound effects have been changed to "compressed in memory" if they aren't used very often.
Resolves #250 